### PR TITLE
fix $1: unbound variable with set -u if no arg is given

### DIFF
--- a/marathon.init
+++ b/marathon.init
@@ -27,7 +27,7 @@ stop() {
   start-stop-daemon --stop --quiet --pidfile "$PID"
 }
 
-case "$1" in
+case "${1-}" in
   start)
     echo -n "Starting $DESC: "
     start


### PR DESCRIPTION
Fixes problem reported in https://github.com/mesosphere/marathon/issues/661
