### PR TITLE
allow loading of EnvironmentFile

### DIFF
--- a/marathon.service
+++ b/marathon.service
@@ -4,6 +4,7 @@ After=network.target
 Wants=network.target
 
 [Service]
+EnvironmentFile=-/etc/sysconfig/marathon
 ExecStart=/usr/bin/marathon
 Restart=always
 RestartSec=20


### PR DESCRIPTION
Allows optional creation of /etc/sysconfig/marathon to set options like e.g.
JAVA_OPTS=-Xmx2G

This follows best practice as defined in:
http://fedoraproject.org/wiki/Packaging%3aSystemd#EnvironmentFiles_and_support_for_.2Fetc.2Fsysconfig_files
