### PR TITLE
Fix debian init script return value when daemon is stopped

### DIFF
--- a/marathon.init
+++ b/marathon.init
@@ -36,6 +36,7 @@ case "${1-}" in
   stop)
     echo -n "Stopping $DESC: "
     stop
+    rm -f "$PID"
     echo "$NAME."
     ;;
   restart)


### PR DESCRIPTION
Add removal of PID file on gracefull shutdown. With pid file present, 'status'
action thinks that daemon crashed without cleaning up its pidfile. Which makes
it difficult to programatically decide if daemon crashed or was stopped.

With this patch, 'status' will use exit codes as defined in LSB specification -
3 for stopped daemon and 1 for crashed daemon that left pid file laying around.