### PR TITLE
add lsb-release as a dependency since is used in the postinst part

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ FPM_OPTS := -s dir -n marathon -v $(PKG_VER) \
 	--vendor "Mesosphere, Inc."
 FPM_OPTS_DEB := -t deb \
 	-d 'java8-runtime-headless | java7-runtime-headless | java6-runtime-headless' \
+	-d 'lsb-release' \
 	--after-install marathon.postinst \
 	--after-remove marathon.postrm
 FPM_OPTS_DEB_INIT := --deb-init marathon.init


### PR DESCRIPTION
Adds lsb-release as a dependency on debian based systems since it's used in the postinst script. Without it the error
```
Setting up marathon (0.10.0-1.0.390.debian81) ...
/var/lib/dpkg/info/marathon.postinst: 5: /var/lib/dpkg/info/marathon.postinst: lsb_release: not found
```
is thrown on minimal installations.