### PR TITLE
Update Java dependency to >= 1.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,13 +24,13 @@ FPM_OPTS := -s dir -n marathon -v $(PKG_VER) \
 	--maintainer "Mesosphere Package Builder <support@mesosphere.io>" \
 	--vendor "Mesosphere, Inc."
 FPM_OPTS_DEB := -t deb \
-	-d 'java8-runtime-headless | java7-runtime-headless | java6-runtime-headless' \
+	-d 'java8-runtime-headless' \
 	-d 'lsb-release' \
 	--after-install marathon.postinst \
 	--after-remove marathon.postrm
 FPM_OPTS_DEB_INIT := --deb-init marathon.init
 FPM_OPTS_RPM := -t rpm \
-	-d coreutils -d 'java >= 1.6'
+	-d coreutils -d 'java >= 1.8'
 FPM_OPTS_OSX := -t osxpkg --osxpkg-identifier-prefix io.mesosphere
 
 .PHONY: help


### PR DESCRIPTION
Updated the deb/rpm Java dependencies, to require Java >= 1.8, as needed by Marathon v0.11.0.

Java 8 is available in Ubuntu >= 14.10, so we might have to stop supporting Ubuntu 12.04 (Precise) and Ubuntu 14.04 (Trusty), or document somewhere that Java 8 has to be installed from an unofficial repository.