### PR TITLE
Fix the rpm Java dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ FPM_OPTS_DEB := -t deb \
 	--after-remove marathon.postrm
 FPM_OPTS_DEB_INIT := --deb-init marathon.init
 FPM_OPTS_RPM := -t rpm \
-	-d coreutils -d 'java >= 1.8'
+	-d coreutils -d 'java >= 1:1.8.0'
 FPM_OPTS_OSX := -t osxpkg --osxpkg-identifier-prefix io.mesosphere
 
 .PHONY: help


### PR DESCRIPTION
Updated the Makefile, so that the rpms we build depend on the right Java version. Without this change, yum won't try to install Java 8.

We have to figure out how to start Marathon using Java 8, even if the default alternative is a previous version.